### PR TITLE
Update pyproject.toml: adding wikontic.db to packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["wikontic", "wikontic.utils"]
+packages = ["wikontic", "wikontic.utils", "wikontic.db"]
 
 [tool.setuptools.package-data]
 wikontic = [


### PR DESCRIPTION
Without wikontic.db in packages, the Wikontic package was not fully installed and did not work.