### PR TITLE
Fix reversed subject and object type definitions in refinement prompts

### DIFF
--- a/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_entity_types.txt
+++ b/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_entity_types.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 The extracted entity types of both subject and object were mapped to a set of similar Wikidata-style entity types based on semantic similarity.
 

--- a/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_relation.txt
+++ b/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_relation.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 
 The extracted relation has been mapped to a set of similar Wikidata-style relations based on semantic similarity and the entity types they can connect.

--- a/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_relation_and_types.txt
+++ b/src/wikontic/utils/prompts/ontology_refinement/prompt_choose_relation_and_types.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 
 The extracted relation has been mapped to a set of similar Wikidata-style relations based on semantic similarity and the entity types they connect.

--- a/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_entity_types.txt
+++ b/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_entity_types.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 The extracted entity types of both subject and object were mapped to a set of similar Wikidata-style entity types based on semantic similarity.
 

--- a/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_relation.txt
+++ b/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_relation.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 
 The extracted relation has been mapped to a set of similar Wikidata-style relations based on semantic similarity and the entity types they can connect.

--- a/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_relation_and_types.txt
+++ b/src/wikontic/utils/prompts_ru/ontology_refinement/prompt_choose_relation_and_types.txt
@@ -3,8 +3,8 @@ You are given a factual triplet extracted from text. The triplet follows the for
 Subject: A named entity or concept that represents a person, group, event, or abstract entity serving as the source of the relation.
 Relation: A Wikidata-style predicate that defines the connection between the subject and the object.
 Object: A named entity or concept that represents a person, group, event, or abstract entity related to the subject.
-Subject_type: a class that describes the object 
-Object_type: a class that describes the subject 
+Subject_type: a class that describes the subject
+Object_type: a class that describes the object
 
 
 The extracted relation has been mapped to a set of similar Wikidata-style relations based on semantic similarity and the entity types they connect.


### PR DESCRIPTION
Hi, thanks for releasing Wikontic.

While reproducing the ontology-refinement pipeline, I noticed that the descriptions of `subject_type` and `object_type` are swapped in several prompts:

```text
  Subject_type: a class that describes the object
  Object_type: a class that describes the subject
```

This is probably not a serious bug, since larger models can usually infer the meaning from the triplet and the rest of the prompt. However, smaller models tend to follow these definitions more literally, so the descriptions can affect entity-type and relation refinement. Correcting them may improve Wikontic's performance, particularly when it is used with smaller models.

This PR changes the descriptions to:
Subject_type: a class that describes the subject
Object_type: a class that describes the object

The fix is applied to the three ontology-refinement prompts under both prompts and prompts_ru. No other behavior is changed.
The same swapped descriptions also appear in the paper appendix, so they may need to be corrected in a future revision as well.